### PR TITLE
Develop

### DIFF
--- a/js/youtube-metadata-bulk.js
+++ b/js/youtube-metadata-bulk.js
@@ -413,7 +413,7 @@ const bulk = (function () {
         const description = idx(["snippet", "description"], video);
         if (description) {
             // https://stackoverflow.com/a/3809435/2650847
-            const URL_REGEX = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&/=]*)/gi;
+            const URL_REGEX = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9@:%_+.~#?&/=]*)/gi;
             const matches = description.match(URL_REGEX);
             if (matches) {
                 for (let j = 0; j < matches.length; j++) {

--- a/js/youtube-metadata-bulk.js
+++ b/js/youtube-metadata-bulk.js
@@ -414,10 +414,11 @@ const bulk = (function () {
         if (description) {
             // https://stackoverflow.com/a/3809435/2650847
             const URL_REGEX = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9@:%_+.~#?&/=]*)/gi;
+            const END_CHARS = /[.()]*$/gi; // Remove periods and parenthesis on end of the link.
             const matches = description.match(URL_REGEX);
             if (matches) {
                 for (let j = 0; j < matches.length; j++) {
-                    const link = matches[j];
+                    const link = matches[j].replace(END_CHARS, "");
 
                     linksData[link] = ++linksData[link] || 1;
                 }


### PR DESCRIPTION
- Fix description link extraction by removing parenthesis from regex
- Remove periods and parenthesis from end of link

Example of links with these characters in a YouTube description
![image](https://user-images.githubusercontent.com/7717432/125362125-5b0c2e80-e33c-11eb-9bf2-e29ac505a682.png)
