### PR TITLE
Develop

### DIFF
--- a/js/youtube-metadata-bulk.js
+++ b/js/youtube-metadata-bulk.js
@@ -1716,7 +1716,13 @@ const bulk = (function () {
                 zip.file("other.csv", otherCsvRows.join("\r\n"));
 
                 console.log("Saving as bulk_metadata.zip")
-                zip.generateAsync({type: "blob"}).then(function (content) {
+                zip.generateAsync({
+                    type: "blob",
+                    compression: "DEFLATE",
+                    compressionOptions: {
+                        level: 9
+                    }
+                }).then(function (content) {
                     saveAs(content, "bulk_metadata.zip");
 
                     controls.btnExport.removeClass("loading").removeClass("disabled");

--- a/js/youtube-metadata.js
+++ b/js/youtube-metadata.js
@@ -1183,7 +1183,13 @@
                 }
 
                 console.log("Saving as metadata.zip")
-                zip.generateAsync({type: "blob"}).then(function (content) {
+                zip.generateAsync({
+                    type: "blob",
+                    compression: "DEFLATE",
+                    compressionOptions: {
+                        level: 9
+                    }
+                }).then(function (content) {
                     saveAs(content, "metadata.zip");
 
                     controls.btnExport.removeClass("loading").removeClass("disabled");


### PR DESCRIPTION
- On export, use max compression. 
    - A channel with 2809 videos went from 29.8MB uncompressed to 2.4MB compressed.
    - A channel with 20000 videos went from 417MB uncompressed to 13.9MB compressed