### PR TITLE
Develop

### DIFF
--- a/bulk.html
+++ b/bulk.html
@@ -45,6 +45,14 @@ script: youtube-metadata-bulk
         <li>other.csv - Other table data.</li>
     </ul>
     </p>
+    <p class='mb-15'>
+    <div class='ui yellow message'>
+        <i class='exclamation triangle icon'></i>
+        YouTube is <a href='https://blog.youtube/news-and-events/update-to-youtube/' target='_blank'>removing the
+        dislikeCount after 2021-12-31</a>.
+        Use the Export button to save dislike data before it goes away.
+    </div>
+    </p>
 </div>
 <div class="ui container" style="margin-top:1.5%">
     <h1>Videos</h1>

--- a/css/youtube-metadata.css
+++ b/css/youtube-metadata.css
@@ -89,3 +89,7 @@ h1 {
 .text-left {
     text-align: left;
 }
+
+.exclamation.triangle {
+    color: orange;
+}

--- a/index.html
+++ b/index.html
@@ -38,6 +38,14 @@ script: youtube-metadata
         <li>channel.json - Raw channel data.</li>
     </ul>
     </p>
+    <p class='mb-15'>
+    <div class='ui yellow message'>
+        <i class='exclamation triangle icon'></i>
+        YouTube is <a href='https://blog.youtube/news-and-events/update-to-youtube/' target='_blank'>removing the
+        dislikeCount after 2021-12-31</a>.
+        Use the Export button to save dislike data before it goes away.
+    </div>
+    </p>
 </div>
 <div class="ui container" style="margin-top:1.5%">
     <div id="video" class="ui section">

--- a/js/youtube-metadata-bulk.js
+++ b/js/youtube-metadata-bulk.js
@@ -10,6 +10,7 @@ const bulk = (function () {
     'use strict';
 
     const controls = {};
+    const BEFORE_2022 = moment().isBefore(moment('2022-01-01'));
 
     const idx = (p, o) => p.reduce((xs, x) => (xs && xs[x]) ? xs[x] : null, o);
 
@@ -894,7 +895,7 @@ const bulk = (function () {
                     display: Number(value).toLocaleString(),
                     num: value
                 } : {
-                    display: "disabled",
+                    display: BEFORE_2022 ? "disabled" : "", // Dislikes will not be returned in 2022
                     num: -1
                 };
             },

--- a/js/youtube-metadata-bulk.js
+++ b/js/youtube-metadata-bulk.js
@@ -888,7 +888,7 @@ const bulk = (function () {
         {
             title: "Dislikes",
             type: "num",
-            visible: true,
+            visible: BEFORE_2022,
             _idx: ["statistics", "dislikeCount"],
             valueMod: function (value) {
                 return value ? {

--- a/js/youtube-metadata.js
+++ b/js/youtube-metadata.js
@@ -240,7 +240,7 @@
                 postProcess: function (partJson) {
                     const partDiv = $("#video-section #statistics");
 
-                    if (partJson.hasOwnProperty("likeCount")) {
+                    if (partJson.hasOwnProperty("likeCount") && partJson.hasOwnProperty("dislikeCount")) {
                         const normalized = normalize(partJson.likeCount, partJson.dislikeCount);
 
                         const html =
@@ -250,7 +250,7 @@
                                 "<span style='color:red'>" + Math.trunc(normalized.b) + " dislike(s)</span>" +
                             "</p>";
                         partDiv.append(html);
-                    } else {
+                    } else if (!partJson.hasOwnProperty("likeCount")) {
                         partDiv.append("<p class='mb-15'>This video has likes disabled.</p>")
                     }
 


### PR DESCRIPTION
- Add alerts that `dislikeCount` is going away
- Update logic to handle `dislikeCount` differently after `2021-12-31`
  - Bulk: dislike column will be hidden by default
  - Dislikes will default to blank instead of disabled when missing
- Logic will still stay to handle when importing a previous export that contains dislikes