### PR TITLE
Develop

### DIFF
--- a/bulk.html
+++ b/bulk.html
@@ -200,7 +200,7 @@ script: youtube-metadata-bulk
 <div class="ui container" style="margin-top:1.5%">
     <h1>Unavailable</h1>
     <p>
-        Videos that are unavailable, they may have been deleted or made private.
+        Videos that are unavailable from channels (created playlists on), playlists, or videos. They are either deleted or made private.
     </p>
 </div>
 <div class="ui container" style="margin-top:1.5%">

--- a/bulk.html
+++ b/bulk.html
@@ -72,13 +72,8 @@ script: youtube-metadata-bulk
     <ul>
         <li>about.txt - Metadata about this result.</li>
         <li>videos.json - Array of all raw video data.</li>
-        <li>videos.csv - Videos table data.</li>
-        <li>tags.csv - Tags table data.</li>
-        <li>geotags.csv - Geotags table data.</li>
-        <li>links.csv - Links table data.</li>
-        <li>frequency.csv - Upload frequency table data (UTC+0).</li>
-        <li>other.csv - Other table data.</li>
-        <li>thumbs/videoId.png - Thumbs if available.</li>
+        <li>✱.csv - Data from each table section below.</li>
+        <li>thumbs/✱.png - Thumbs if available.</li>
     </ul>
     </p>
     <p class='mb-15'>
@@ -200,6 +195,15 @@ script: youtube-metadata-bulk
         </select>
     </p>
     <div id="uploadFrequency"></div>
+</div>
+<div class="ui container" style="margin-top:1.5%">
+    <h1>Unavailable</h1>
+    <p>
+        Playlist videos that are unavailable, they may have been deleted or made private.
+    </p>
+</div>
+<div class="ui container" style="margin-top:1.5%">
+    <table id="unavailableTable" class="display" style="width:100%"></table>
 </div>
 <div class="ui container" style="margin-top:1.5%">
     <h1>Other</h1>

--- a/bulk.html
+++ b/bulk.html
@@ -72,6 +72,7 @@ script: youtube-metadata-bulk
     <ul>
         <li>about.txt - Metadata about this result.</li>
         <li>videos.json - Array of all raw video data.</li>
+        <li>unavailable.json - Basic data for unavailable videos.</li>
         <li>✱.csv - Data from each table section below.</li>
         <li>thumbs/✱.png - Thumbs if available.</li>
     </ul>
@@ -199,7 +200,7 @@ script: youtube-metadata-bulk
 <div class="ui container" style="margin-top:1.5%">
     <h1>Unavailable</h1>
     <p>
-        Playlist videos that are unavailable, they may have been deleted or made private.
+        Videos that are unavailable, they may have been deleted or made private.
     </p>
 </div>
 <div class="ui container" style="margin-top:1.5%">

--- a/js/youtube-metadata-bulk.js
+++ b/js/youtube-metadata-bulk.js
@@ -149,6 +149,17 @@ const bulk = (function () {
             console.log("done");
             console.log(videoIds);
 
+            const resultIds = [];
+            for (let i = 0; i < rawVideoData.length; i++) {
+                resultIds.push(rawVideoData[i].id);
+            }
+            for (let i = 0; i < videoIds.length; i++) {
+                const videoId = videoIds[i];
+                if (!unavailableData.hasOwnProperty(videoId) && resultIds.indexOf(videoId) === -1) {
+                    unavailableData[videoId] = {title: "Did not come back in API."};
+                }
+            }
+
             controls.videosTable.columns.adjust().draw(false);
 
             setTimeout(loadAggregateTables, 200);


### PR DESCRIPTION
- Bulk: Add new `Unavailable` section with links to research them
  - In normal playlists, unavailable videos still come back from playlistItems.list and show the title as deleted/private.
  - The typical channel uploads playlist does not list deleted/private video ids.
  - Also, will list videos that did not come back that had been input if using direct video links.