### PR TITLE
Develop

### DIFF
--- a/bulk.html
+++ b/bulk.html
@@ -170,6 +170,7 @@ script: youtube-metadata-bulk
         Videos that are unavailable from channels (created playlists on), playlists, or videos.
         They are either deleted or made private.
         Consider searching for user-made playlists to find more unavailable videos.
+        Filmot may also reveal unlisted and unavailable videos that can't be found in playlists.
     </p>
     <label for="unavailable-columns">Select column(s)</label>
     <select id="unavailable-columns" multiple="multiple" hidden></select>

--- a/js/youtube-metadata.js
+++ b/js/youtube-metadata.js
@@ -47,6 +47,7 @@
             }
         } else if (filmot) {
             data["video_title"] = filmot.title;
+            data["channel_id"] = filmot.channelid;
             data["channel_title"] = filmot.channelname;
         }
         console.log(data);


### PR DESCRIPTION
- Normal: channelid suggestions for filmot unavailable videos
- Bulk
  - Improve loading statuses for normal submission and import
  - Videos table only loads entries when done processing video ids, improving performance. Previously it would get slower and slower the more thousands of video ids were being processed as it added them to the table in groups of 50 instead of 1000.
  - Show channel progress + fix to only query unique channel ids
  - Done status now displays video, unavailable, channel, and playlist counts