### PR TITLE
Develop

### DIFF
--- a/js/youtube-metadata-bulk.js
+++ b/js/youtube-metadata-bulk.js
@@ -943,7 +943,7 @@ const bulk = (function () {
                 "<a target='_blank' href='https://filmot.com/video/" + videoId + "'>Filmot</a> · " +
                 "<a target='_blank' href='https://web.archive.org/web/*/https://www.youtube.com/watch?v=" + videoId + "'>Archive Web</a> · " +
                 "<a target='_blank' href='https://archive.org/details/youtube-" + videoId + "'>Archive Details</a> · " +
-                "<a target='_blank' href='https://web.archive.org/web/2/http://wayback-fakeurl.archive.org/yt/" + videoId + "'>Archive Video</a> · " +
+                "<a target='_blank' href='https://web.archive.org/web/2oe_/http://wayback-fakeurl.archive.org/yt/" + videoId + "'>Archive Video</a> · " +
                 "<a target='_blank' href='https://www.google.com/search?q=\"" + videoId + "\"'>Google</a>",
                 video.source,
                 filmotTitle,

--- a/js/youtube-metadata.js
+++ b/js/youtube-metadata.js
@@ -87,7 +87,11 @@
             });
             suggestions.push({
                 url: "https://web.archive.org/web/2/http://wayback-fakeurl.archive.org/yt/" + data.video_id,
-                text: "Archive.org (direct video) - " + data.video_id
+                text: "Archive.org (direct video 1) - " + data.video_id
+            });
+            suggestions.push({
+                url: "https://web.archive.org/web/2oe_/http://wayback-fakeurl.archive.org/yt/" + data.video_id,
+                text: "Archive.org (direct video 2) - " + data.video_id
             });
             suggestions.push({
                 url: "https://filmot.com/video/" + data.video_id,


### PR DESCRIPTION
- Add additional direct video link with `2oe_` instead of just `2`.
    - `2` returns the video with wayback header included and is returned in an embedded way
    - `2oe_` returns the video raw with no wayback header
    - Unclear why but sometimes `2` returns no video found when there is one but `2oe_` will return the video without a problem