### PR TITLE
Develop

### DIFF
--- a/js/shared.js
+++ b/js/shared.js
@@ -24,6 +24,9 @@ const shared = (function () {
         channel_user: [
             /(?:http[s]?:\/\/)?(?:\w+\.)?youtube.com\/user\/([\w_-]+)(?:\?.*)?/i
         ],
+        channel_handle: [
+            /(?:http[s]?:\/\/)?(?:\w+\.)?youtube.com\/@([^\/?]+)(?:\?.*)?/i,
+        ],
         channel_custom: [
             /(?:http[s]?:\/\/)?(?:\w+\.)?youtube.com\/c\/([^\/?]+)(?:\?.*)?/i,
             /(?:http[s]?:\/\/)?(?:\w+\.)?youtube.com\/([^\/?]+)(?:\?.*)?/i
@@ -66,7 +69,7 @@ const shared = (function () {
 
         isValidChannelId: function (channelId) {
             return channelId !== undefined && channelId !== null &&
-                String(channelId).match(/[A-Za-z0-9_-]{21}[AQgw]/);
+                String(channelId).match(/[A-Za-z0-9_-]{23}[AQgw]/);
         },
 
         parseQuery: function (queryString) {


### PR DESCRIPTION
- Support upcoming channel handle URLs
- Page doesn't contain `og:url` property in initial response but am able to extract the channel id from a value in script JS in the response with regex.
- Example: `https://www.youtube.com/@youtubecreators`